### PR TITLE
build: update repository address

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ members = [
 [workspace.package]
 edition = "2021"
 version = "0.0.1"
-repository = "https://github.com/wmitros/scylla-rust-udf"
+repository = "https://github.com/scylladb/scylla-rust-udf"
 license = "MIT OR Apache-2.0"
 rust-version = "1.66.1"
 


### PR DESCRIPTION
Because the repository has been moved to a different address, the URL in Cargo.toml should be changed as well.