### PR TITLE
build: update version to 0.1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # Rust helper library for Scylla UDFs
 
+This crate allows writing pure Rust functions that can be used as Scylla UDFs.
+
+**Note: this crate is officially supported and ready to use. However, UDFs are still an experimental feature in ScyllaDB, and the crate has not been widely used, which is why it's still in beta and its API is subject to change. We appreciate bug reports and pull requests!**
+
 ## Usage
 
 ### Prerequisites

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -1,9 +1,7 @@
 [package]
 name = "examples"
+version = "0.0.0"
 edition.workspace = true
-version.workspace = true
-repository.workspace = true
-license.workspace = true
 rust-version.workspace = true
 publish = false
 
@@ -11,7 +9,7 @@ publish = false
 chrono = "0.4"
 bigdecimal = "0.2.0"
 num-bigint = "0.3"
-scylla-udf = { workspace = true }
+scylla-udf = { version = "0.1.0", path = "../scylla-udf" }
 uuid = "1.0"
 
 [[example]]

--- a/scylla-udf-macros/Cargo.toml
+++ b/scylla-udf-macros/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "scylla-udf-macros"
+version = "0.1.0"
 edition.workspace = true
-version.workspace = true
 repository.workspace = true
 license.workspace = true
 rust-version.workspace = true

--- a/scylla-udf/Cargo.toml
+++ b/scylla-udf/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "scylla-udf"
+version = "0.1.0"
 edition.workspace = true
-version.workspace = true
 repository.workspace = true
 license.workspace = true
 rust-version.workspace = true
@@ -16,6 +16,6 @@ bytes = "1.2.1"
 chrono = "0.4"
 libc = "0.2.119"
 num-bigint = "0.3"
-scylla-udf-macros = { workspace = true }
+scylla-udf-macros = { version = "0.1.0", path = "../scylla-udf-macros" }
 scylla-cql = "0.0.4"
 uuid = "1.0"

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -1,14 +1,12 @@
 [package]
 name = "tests"
+version = "0.0.0"
 edition.workspace = true
-version.workspace = true
-repository.workspace = true
-license.workspace = true
 rust-version.workspace = true
 publish = false
 
 [dependencies]
-scylla-udf = { workspace = true }
+scylla-udf = { version = "0.1.0", path = "../scylla-udf" }
 bigdecimal = "0.2.0"
 bytes = "1.2.1"
 chrono = "0.4"


### PR DESCRIPTION
The crate is ready for release, but considering that is hasn't been yet tested by public, and UDFs are still experimental in Scylla, we're not releasing a major version yet.