### PR TITLE
readme: improve instructions concerning NULLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,8 +105,7 @@ If CQL types `T1`, `T2`, ... map to Rust types `RustT1`, `RustT2`, ..., you can 
 
 ### Nulls
 
-If a CQL Value of type T, that's mapped to type RustT, may be a null (possible in non-`RETURNS NULL ON NULL INPUT` UDFs),
-the type used in the Rust function should be Option\<RustT\>.
+If a CQL Value of type T that's mapped to type RustT may be a null (all parameter and return types in `CALLED ON NULL INPUT` UDFs), then the type used in the Rust function should be Option\<RustT\>.
 
 ## Contributing
 


### PR DESCRIPTION
Scylla treats `CALLED ON NULL INPUT RETURNS` UDFs as if all their parameters and return value could be nulls. That means, in particular, that the return type of corresponding Rust UDFs should be an Option<T>, which is not obvious, so it should be included in the readme.

## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
~~- [] I added relevant tests for new features and bug fixes.~~
- [x] All commits compile, pass static checks and pass tests.
- [x] PR description sums up the changes and reasons why they should be introduced.
~~- [ ] I added appropriate `Fixes:` annotations to PR description.~~
